### PR TITLE
Enhancement: Reduction of memory usage for very large files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ test/*.txt
 deps/deps.jl
 docs/build/
 docs/tutorial/results.mat
+results/*

--- a/src/COBRA.jl
+++ b/src/COBRA.jl
@@ -7,7 +7,7 @@
 
 #-------------------------------------------------------------------------------------------
 
-VERSION >= v"0.4"
+VERSION >= v"0.5"
 
 """
 Main module for `COBRA.jl` - COnstraint-Based Reconstruction and Analysis in Julia

--- a/src/checkSetup.jl
+++ b/src/checkSetup.jl
@@ -26,11 +26,11 @@ See also: `using`, `isdir()`
 function checkPackage(pkgname)
 
     try
-        eval(Expr(:using,pkgname))
+        eval(Expr(:using, pkgname))
         return true
     catch
         if isdir(Pkg.dir((string(pkgname))))
-           print_with_color(:yellow, "Package ",string(pkgname),
+           print_with_color(:yellow, "Package ", string(pkgname),
                " is installed but couldn't be loaded. ",
                "You may need to run `Pkg.build(\"$pkgname\")`\n")
         else

--- a/src/connect.jl
+++ b/src/connect.jl
@@ -37,7 +37,7 @@ See also: `workers()`, `nprocs()`, `addprocs()`, `gethostname()`
 
 """
 
-function createPool(localWorkers::Int, connectSSH::Bool=false)
+function createPool(localWorkers::Int, connectSSH::Bool = false)
 
     # load cores on remote nodes
     if connectSSH

--- a/src/distributedFBA.jl
+++ b/src/distributedFBA.jl
@@ -45,8 +45,8 @@ See also: `solveCobraLP()`, `distributedFBA()`
 
 """
 
-function preFBA!(model, solver, optPercentage::Float64=100.0, osenseStr::String="max",
-                        rxnsList::Array{Int, 1}=ones(Int, length(model.rxns)))
+function preFBA!(model, solver, optPercentage::Float64 = 100.0, osenseStr::String = "max",
+                        rxnsList::Array{Int, 1} = ones(Int, length(model.rxns)))
 
     # constants
     OPT_PERCENTAGE = 90.0
@@ -105,9 +105,9 @@ function preFBA!(model, solver, optPercentage::Float64=100.0, osenseStr::String=
 
         # change the sense of the constraints vector based on the objective sense
         if osenseStr == "max"
-          push!(model.csense, '>')
+            push!(model.csense, '>')
         else
-          push!(model.csense, '<')
+            push!(model.csense, '<')
         end
 
         return objValue, fbaSol
@@ -169,7 +169,7 @@ function splitRange(model, rxnsList, nWorkers::Int = 1, strategy::Int = 0)
 
     # output the average load per worker and the splitting strategy
     print_with_color(:blue, "Average load per worker: $pRxnsWorker reactions ($nWorkers workers).\n")
-    print_with_color(:blue, "Spliting strategy is $strategy.\n")
+    print_with_color(:blue, "Splitting strategy is $strategy.\n\n")
 
     # define indices for each worker p
     istart      = zeros(Int, nWorkers)
@@ -327,12 +327,12 @@ See also: `distributeFBA()`, `MathProgBase.HighLevelInterface`
 
 """
 
-function loopFBA(m, rxnsList, nRxns::Int, rxnsOptMode = 2+zeros(Int,length(rxnsList)), iRound::Int = 0, pid::Int = 1)
+function loopFBA(m, rxnsList, nRxns::Int, rxnsOptMode = 2 + zeros(Int,length(rxnsList)), iRound::Int = 0, pid::Int = 1)
 
     # initialize vectors and counters
     retObj  = zeros(nRxns)
     retStat = -1 + zeros(Int, nRxns)
-    retFlux = zeros(nRxns,nRxns)
+    retFlux = zeros(nRxns, length(rxnsList))
     j       = 1
 
     # loop over all the reactions
@@ -340,15 +340,15 @@ function loopFBA(m, rxnsList, nRxns::Int, rxnsOptMode = 2+zeros(Int,length(rxnsL
 
         # determine the optimization mode
         if (rxnsOptMode[k] == 0 && iRound == 0) || (rxnsOptMode[k] == 1 && iRound == 1) || (rxnsOptMode[k] == 2)
-           performOptim = true
+            performOptim = true
         else
-           performOptim = false
+            performOptim = false
         end
 
         if performOptim
             # change the sense of the optimization
             if j == 1
-                if iRound == 0 #&& rxnsOptMode[k] == 0
+                if iRound == 0
                     MathProgBase.HighLevelInterface.setsense!(m, :Min)
                     println(" -- Minimization (iRound = $iRound). Block $pid [$(length(rxnsList))/$nRxns].")
                 else
@@ -359,7 +359,7 @@ function loopFBA(m, rxnsList, nRxns::Int, rxnsOptMode = 2+zeros(Int,length(rxnsL
 
             # Set the objective vector coefficients
             c = zeros(nRxns)
-            c[rxnsList[k]] = 1000.0 # current FBA
+            c[rxnsList[k]] = 1000.0 # set the coefficient of the current FBA to 1000
 
             # set the objective of the CPLEX model
             MathProgBase.HighLevelInterface.setobj!(m, c)
@@ -380,7 +380,7 @@ function loopFBA(m, rxnsList, nRxns::Int, rxnsOptMode = 2+zeros(Int,length(rxnsL
                 retObj[rxnsList[k]] = solutionLP.objval / 1000.0
 
                 # retrieve the solution vector
-                retFlux[:,rxnsList[k]] = solutionLP.sol
+                retFlux[:, k] = solutionLP.sol
 
                 # return the solution status
                 retStat[rxnsList[k]] = 1 # LP problem is optimal
@@ -401,7 +401,7 @@ function loopFBA(m, rxnsList, nRxns::Int, rxnsOptMode = 2+zeros(Int,length(rxnsL
                 retStat[rxnsList[k]] = 5 # LP problem has a non-documented solution status
             end
 
-            j = j+1 # increase the counter for the return flux vector
+            j = j + 1 # increase the counter for the return flux vector
         end # end condition performOptim
     end #end k loop
 
@@ -411,7 +411,7 @@ end
 
 # ------------------------------------------------------------------------------------------
 """
-    distributedFBA(model, solver, nWorkers, optPercentage, objective, rxnsList, strategy, preFBA, rxnsOptMode)
+    distributedFBA(model, solver, nWorkers, optPercentage, objective, rxnsList, strategy, preFBA, rxnsOptMode, saveChunks)
 
 Function to distribute a series of FBA problems across one or more workers that have been
 initialized using the `createPool` function (or similar).
@@ -438,17 +438,20 @@ initialized using the `createPool` function (or similar).
     - 2: minimization & maximization
       [default: all reactions are minimized and maximized, i.e. 2+zeros(Int,length(model.rxns))]
 - `preFBA`:         Boolean to solve the original FBA and add a percentage condition (default: true)
+- `saveChunks`:     Save the fluxes of the minimizations and maximizations in individual files on each worker (applicable for large models)
 
 # OUTPUTS
 
-- `minFlux`:          Minimum flux for each reaction
-- `maxFlux`:          Maximum flux for each reaction
-- `optSol`:           Optimal solution of the initial FBA
-- `fbaSol`:           Solution vector of the initial FBA
-- `fvamin`:           Array with flux values for the considered reactions (minimization)
-- `fvamax`:           Array with flux values for the considered reactions (maximization)
-- `statussolmin`:     Vector of solution status for each reaction (minimization)
-- `statussolmax`:     Vector of solution status for each reaction (maximization)
+- `minFlux`:        Minimum flux for each reaction
+- `maxFlux`:        Maximum flux for each reaction
+- `optSol`:         Optimal solution of the initial FBA
+- `fbaSol`:         Solution vector of the initial FBA
+- `fvamin`:         Array with flux values for the considered reactions (minimization)
+      Note: `fvamin` is saved in individual `.mat` files when `saveChunks` is `true`.
+- `fvamax`:         Array with flux values for the considered reactions (maximization)
+      Note: `fvamax` is saved in individual `.mat` files when `saveChunks` is `true`.
+- `statussolmin`:   Vector of solution status for each reaction (minimization)
+- `statussolmax`:   Vector of solution status for each reaction (maximization)
 
 # EXAMPLES
 
@@ -465,13 +468,16 @@ julia> minFlux, maxFlux, optSol, fbaSol, fvamin, fvamax, statussolmin, statussol
 See also: `preFBA!()`, `splitRange()`, `buildCobraLP()`, `loopFBA()`, or `fetch()`
 """
 
-function distributedFBA(model, solver, nWorkers::Int = 1, optPercentage::Float64=100.0, objective::String = "max",
-                        rxnsList = 1:length(model.rxns),
-                        strategy::Int = 0, rxnsOptMode = 2+zeros(Int,length(model.rxns)), preFBA::Bool = true)
+function distributedFBA(model, solver, nWorkers::Int = 1, optPercentage::Float64 = 100.0, objective::String = "max",
+                        rxnsList = 1:length(model.rxns), strategy::Int = 0,
+                        rxnsOptMode = 2 + zeros(Int,length(model.rxns)), preFBA::Bool = true, saveChunks::Bool = false)
 
     # calculate a default FBA solution
     if preFBA
+        startTime   = time()
         optSol, fbaSol = preFBA!(model, solver, optPercentage, objective)
+        solTime = time() - startTime
+        print_with_color(:green, "Original FBA solved. Solution time: $solTime s.\n\n")
     else
         optSol = 0.0
         fbaSol = zeros(length(model.rxns))
@@ -489,8 +495,30 @@ function distributedFBA(model, solver, nWorkers::Int = 1, optPercentage::Float64
     maxFlux = zeros(nRxns)
 
     # initialilze the flux matrices
-    fvamax  = zeros(nRxns, nRxns)
-    fvamin  = zeros(nRxns, nRxns)
+    if !saveChunks
+        fvamax  = zeros(nRxns, nRxns)
+        fvamin  = zeros(nRxns, nRxns)
+    else
+        # create a folder for storing the results
+        if !isdir("$(dirname(@__FILE__))/../results")
+            mkdir("$(dirname(@__FILE__))/../results")
+            print_with_color(:green, "Directory `results` created.\n\n")
+
+            # create a folder for storing the chunks of the fluxes of each minimization
+            if !isdir("$(dirname(@__FILE__))/../results/fvamin")
+                mkdir("$(dirname(@__FILE__))/../results/fvamin")
+            end
+
+            # create a folder for storing the chunks of the fluxes of each maximization
+            if !isdir("$(dirname(@__FILE__))/../results/fvamax")
+                mkdir("$(dirname(@__FILE__))/../results/fvamax")
+            end
+        else
+            print_with_color(:cyan, "Directory `results` already exists.\n\n")
+        end
+        fvamin = zeros(1)
+        fvamax = zeros(1)
+    end
 
     # initialize the vectors to report the solution status
     statussolmin = zeros(Int, nRxns)
@@ -508,7 +536,7 @@ function distributedFBA(model, solver, nWorkers::Int = 1, optPercentage::Float64
        println(" >> All $nRxns reactions of the model will be solved (100 \%).\n")
     end
 
-    if nRxns > 20000 && nWorkers <= 4
+    if (nRxnsList > 20000 && nWorkers <= 4) || (nRxns > 100000 && !saveChunks)
         warn("\nTrying to solve more than 20000 optimization problems on fewer than 4 workers. Memory might be limited.")
         info(" >> Try running this analysis on a cluster, or use a larger parallel pool.\n")
     end
@@ -520,12 +548,12 @@ function distributedFBA(model, solver, nWorkers::Int = 1, optPercentage::Float64
         rxnsKey = splitRange(model, rxnsList, nWorkers, strategy)
 
         # prepare array for storing remote references
-        R = Array{Future}(nWorkers,2)
+        R = Array{Future}(nWorkers, 2)
 
         # distribution across workers
         @sync for (p, pid) in enumerate(workers())
             for iRound=0:1
-                R[p,iRound+1] = @spawnat (p+1) begin
+                @async R[p, iRound+1] = @spawnat (p+1) begin
                     m = buildCobraLP(model, solver) # on each worker, the model must be built individually
                     loopFBA(m, rxnsList[rxnsKey[p]], nRxns, rxnsOptMode[rxnsKey[p]], iRound, pid)
                 end
@@ -533,14 +561,33 @@ function distributedFBA(model, solver, nWorkers::Int = 1, optPercentage::Float64
         end
 
         # assemble the vectors
-        for (p, pid) in enumerate(workers())
+        @sync for (p, pid) in enumerate(workers())
+
             # save the minimum and maximum
             minFlux[rxnsList[rxnsKey[p]]] = fetch(R[p,1])[1][rxnsList[rxnsKey[p]]]
             maxFlux[rxnsList[rxnsKey[p]]] = fetch(R[p,2])[1][rxnsList[rxnsKey[p]]]
 
             # save the fluxes of each reaction
-            fvamin[:, rxnsList[rxnsKey[p]]] = fetch(R[p,1])[2][:,rxnsList[rxnsKey[p]]]
-            fvamax[:, rxnsList[rxnsKey[p]]] = fetch(R[p,2])[2][:,rxnsList[rxnsKey[p]]]
+            if saveChunks
+                if p == 1 println() end
+                print(" Saving the minimum and maximum fluxes for reactions $(rxnsList[rxnsKey[p]]) from worker $p ... ")
+
+                # open 2 file streams
+                filemin = matopen("$(dirname(@__FILE__))/../results/fvamin/fvamin_$p.mat", "w")
+                filemax = matopen("$(dirname(@__FILE__))/../results/fvamax/fvamax_$p.mat", "w")
+
+                # save the reaction key for each worker into each file
+                write(filemin, "fvamin", fetch(R[p,1])[2][:, :])
+                write(filemax, "fvamax", fetch(R[p,2])[2][:, :])
+
+                # close the 2 file streams
+                close(filemin)
+                close(filemax)
+                print_with_color(:green, "Done.\n")
+            else
+                fvamin[:, rxnsList[rxnsKey[p]]] = fetch(R[p,1])[2][:, :]
+                fvamax[:, rxnsList[rxnsKey[p]]] = fetch(R[p,2])[2][:, :]
+            end
 
             # save the solver status for each reaction
             statussolmin[rxnsList[rxnsKey[p]]] = fetch(R[p,1])[3][rxnsList[rxnsKey[p]]]
@@ -560,18 +607,24 @@ end
 
 #-------------------------------------------------------------------------------------------
 """
-    printSolSummary(testFile::String, optSol, maxFlux, minFlux, solTime, nWorkers, solverName)
+    printSolSummary(testFile, optSol, maxFlux, minFlux, solTime, nWorkers, solverName, strategy = 0)
 
 Output a solution summary
 
 # INPUTS
 
-- `optSol`:           Optimal solution of the initial FBA
-- `minFlux`:          Minimum flux for each reaction
-- `maxFlux`:          Maximum flux for each reaction
-- `solTime`:          Solution time (in seconds)
-- `nWorkers`:         Number of workers as initialized using `createPool()` or similar
-- `solverName`:       Name of the solver
+- `testFile`:       Name of the `.mat` test file
+- `optSol`:         Optimal solution of the initial FBA
+- `minFlux`:        Minimum flux for each reaction
+- `maxFlux`:        Maximum flux for each reaction
+- `solTime`:        Solution time (in seconds)
+- `nWorkers`:       Number of workers as initialized using `createPool()` or similar
+- `solverName`:     Name of the solver
+- `strategy`:       Number of the splitting strategy
+    - 0: Blind splitting: default random distribution
+    - 1: Extremal dense-and-sparse splitting: every worker receives dense and sparse reactions, starting from both extremal indices of the sorted column density vector
+    - 2: Central dense-and-sparse splitting: every worker receives dense and sparse reactions, starting from the beginning and center indices of the sorted column density vector
+- `saveChunks`:     Save the fluxes of the minimizations and maximizations in individual files on each worker (applicable for large models)
 
 # OUTPUTS
 
@@ -581,7 +634,9 @@ See also: `norm()`, `maximum()`, `minimum()`
 
 """
 
-function printSolSummary(testFile::String, optSol, maxFlux, minFlux, solTime, nWorkers, solverName)
+function printSolSummary(testFile::String, optSol, maxFlux, minFlux, solTime, nWorkers, solverName, strategy = 0, saveChunks = false)
+
+    # print a solution summary
     println("\n-- Solution summary --\n")
     print_with_color(:blue, "$testFile\n")
     println(" Original FBA obj.val         ", optSol)
@@ -594,6 +649,10 @@ function printSolSummary(testFile::String, optSol, maxFlux, minFlux, solTime, nW
     println(" Solution time [s]:           ", solTime)
     println(" Number of workers:           ", nWorkers)
     println(" Solver:                      ", solverName)
+    println(" Distribution strategy:       ", strategy)
+    println(" Saving individual files:     ", saveChunks)
+    println()
+
 end
 
 #------------------------------------------------------------------------------------------
@@ -620,18 +679,31 @@ function saveDistributedFBA(fileName::String)
     # set the list of variables
     vars = ["minFlux", "maxFlux", "optSol", "fbaSol", "fvamin", "fvamax", "statussolmin", "statussolmax"]
 
+    countSavedVars = 0
+
     # loop through the list of variables
     for i = 1:length(vars)
         if isdefined(Main, Symbol(vars[i]))
             print("Saving $(vars[i])...")
             write(file, "$(vars[i])", eval(Main, Symbol(vars[i])))
+
+            # increment the counter
+            countSavedVars = countSavedVars + 1
+
             print_with_color(:green, "Done.\n")
         end
     end
 
     # close the file and return a status message
     close(file)
-    print_with_color(:green, "All available variables saved to $(pwd())/$fileName.\n")
+
+    # print a status message
+    if countSavedVars > 0
+        print_with_color(:green, "All available variables saved to $(pwd())/$fileName.\n")
+    else
+        warn("No variables saved.")
+    end
+
 end
 
 #------------------------------------------------------------------------------------------

--- a/src/load.jl
+++ b/src/load.jl
@@ -76,7 +76,7 @@ julia> model = loadModel("myModel.mat", "A", "myModelName", ["ub","lb","osense",
 See also: `MAT.jl`, `matopen()`, `matread()`
 """
 
-function loadModel(fileName::String, matrixAS::String="S", modelName::String="model", modelFields::Array{String,1}=["ub","lb","osense","c","b","csense","rxns","mets"])
+function loadModel(fileName::String, matrixAS::String = "S", modelName::String = "model", modelFields::Array{String,1} = ["ub", "lb", "osense", "c", "b", "csense", "rxns", "mets"])
 
     file = matopen(fileName)
     vars = matread(fileName)

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -93,7 +93,7 @@ julia> changeCobraSolver("CPLEX", cpxControl)
 See also: `MathProgBase.jl`
 """
 
-function changeCobraSolver(name, params=[])
+function changeCobraSolver(name, params = [])
 
     # convert type of name
     if typeof(name) != :String

--- a/test/p_all.jl
+++ b/test/p_all.jl
@@ -106,7 +106,7 @@ minFlux, maxFlux, optSol, fbaSol, fvamin, fvamax, statussolmin, statussolmax = d
 # print a solution summary with full output
 printSolSummary(testFile, optSol, maxFlux, minFlux, solTime, nWorkers, solverName, strategy, saveChunks)
 
-# remove the file to clean up
+# remove the results folder to clean up
 run(`rm -rf $(dirname(@__FILE__))/../results`)
 
 # create folders if they are not present
@@ -131,3 +131,6 @@ minFlux, maxFlux, optSol, fbaSol, fvamin, fvamax, statussolmin, statussolmax = d
 
 # print a solution summary with full output
 printSolSummary(testFile, optSol, maxFlux, minFlux, solTime, nWorkers, solverName, strategy, saveChunks)
+
+# remove the results folder to clean up
+run(`rm -rf $(dirname(@__FILE__))/../results`)

--- a/test/p_all.jl
+++ b/test/p_all.jl
@@ -14,11 +14,11 @@ if !isdefined(:includeCOBRA) includeCOBRA = true end
 # output information
 testFile = @__FILE__
 
+# number of workers
 nWorkers = 4
 
 # create a pool and use the COBRA module if the testfile is run in a loop
 if includeCOBRA
-
     solverName = :GLPKMathProgInterface
     connectSSHWorkers = false
     include("$(dirname(@__FILE__))/../src/connect.jl")
@@ -45,7 +45,7 @@ rxnsList = 1:length(model.rxns)
 
 for s = 0:2
     # launch the distributedFBA process
-    startTime   = time()
+    startTime = time()
     minFlux, maxFlux, optSol = distributedFBA(model, solver, nWorkers, 90.0, "max", rxnsList, s)
     solTime = time() - startTime
 
@@ -56,14 +56,14 @@ for s = 0:2
     @test floor(minimum(minFlux)) == -36.0
     @test floor(norm(maxFlux))    == 1427.0
     @test floor(norm(minFlux))    == 93.0
-    @test abs((- model.c'*minFlux)[1] - optSol) < 1e-9
+    @test abs((- model.c' * minFlux)[1] - optSol) < 1e-9
 
     # print a solution summary
     printSolSummary(testFile, optSol, maxFlux, minFlux, solTime, nWorkers, solverName)
 end
 
 # launch the distributedFBA process
-startTime   = time()
+startTime = time()
 minFlux, maxFlux, optSol, fbaSol, fvamin, fvamax = distributedFBA(model, solver, nWorkers)
 solTime = time() - startTime
 
@@ -74,7 +74,7 @@ solTime = time() - startTime
 @test floor(minimum(minFlux)) == -46.0
 @test floor(norm(maxFlux))    == 1414.0
 @test floor(norm(minFlux))    == 106.0
-@test abs((- model.c'*minFlux)[1] - optSol) < 1e-9
+@test abs((- model.c' * minFlux)[1] - optSol) < 1e-9
 
 # save the variables to the current directory
 saveDistributedFBA("testFile.mat")
@@ -86,14 +86,14 @@ run(`rm testFile.mat`)
 printSolSummary(testFile, optSol, maxFlux, minFlux, solTime, nWorkers, solverName)
 
 # define model and solution parameters
-optPercentage     = 90.0
-objective         = "max"
-maxtrixAS         = "S"
-modelName         = "model"
+optPercentage = 90.0
+objective = "max"
+maxtrixAS = "S"
+modelName = "model"
 
 # test to save individual result files (chunks)
-saveChunks  = true
-strategy    = 0
+saveChunks = true
+strategy = 0
 
 # select the number of reactions
 rxnsList = 1:length(model.rxns)

--- a/test/p_all.jl
+++ b/test/p_all.jl
@@ -84,3 +84,50 @@ run(`rm testFile.mat`)
 
 # print a solution summary
 printSolSummary(testFile, optSol, maxFlux, minFlux, solTime, nWorkers, solverName)
+
+# define model and solution parameters
+optPercentage     = 90.0
+objective         = "max"
+maxtrixAS         = "S"
+modelName         = "model"
+
+# test to save individual result files (chunks)
+saveChunks  = true
+strategy    = 0
+
+# select the number of reactions
+rxnsList = 1:length(model.rxns)
+
+# select the reaction optimization mode
+rxnsOptMode = 2 + zeros(Int64, length(rxnsList))
+
+minFlux, maxFlux, optSol, fbaSol, fvamin, fvamax, statussolmin, statussolmax = distributedFBA(model, solver, nWorkers, optPercentage, objective, rxnsList, strategy, rxnsOptMode, true, saveChunks)
+
+# print a solution summary with full output
+printSolSummary(testFile, optSol, maxFlux, minFlux, solTime, nWorkers, solverName, strategy, saveChunks)
+
+# remove the file to clean up
+run(`rm -rf $(dirname(@__FILE__))/../results`)
+
+# create folders if they are not present
+if !isdir("$(dirname(@__FILE__))/../results")
+    mkdir("$(dirname(@__FILE__))/../results")
+    print_with_color(:green, "Directory `results` created.\n\n")
+
+    # create a folder for storing the chunks of the fluxes of each minimization
+    if !isdir("$(dirname(@__FILE__))/../results/fvamin")
+        mkdir("$(dirname(@__FILE__))/../results/fvamin")
+    end
+
+    # create a folder for storing the chunks of the fluxes of each maximization
+    if !isdir("$(dirname(@__FILE__))/../results/fvamax")
+        mkdir("$(dirname(@__FILE__))/../results/fvamax")
+    end
+else
+    print_with_color(:cyan, "Directory `results` already exists.\n\n")
+end
+
+minFlux, maxFlux, optSol, fbaSol, fvamin, fvamax, statussolmin, statussolmax = distributedFBA(model, solver, nWorkers, optPercentage, objective, rxnsList, strategy, rxnsOptMode, true, saveChunks)
+
+# print a solution summary with full output
+printSolSummary(testFile, optSol, maxFlux, minFlux, solTime, nWorkers, solverName, strategy, saveChunks)

--- a/test/p_distinct.jl
+++ b/test/p_distinct.jl
@@ -14,11 +14,11 @@ if !isdefined(:includeCOBRA) includeCOBRA = true end
 # output information
 testFile = @__FILE__
 
+# number of workers
 nWorkers = 4
 
 # create a pool and use the COBRA module if the testfile is run in a loop
 if includeCOBRA
-
     solverName = :GLPKMathProgInterface
     connectSSHWorkers = false
     include("$(dirname(@__FILE__))/../src/connect.jl")
@@ -43,16 +43,16 @@ model = loadModel("ecoli_core_model.mat", "S", "model")
 # run all the reactions as a reference
 minFlux1, maxFlux1, optSol1, fbaSol1, fvamin1, fvamax1, statussolmin1, statussolmax1 = distributedFBA(model, solver, nWorkers, 90.0, "max")
 
-rxnsList = [1;2;3;4;12;28]
-rxnsOptMode = [0;1;2;0;1;2] # min: 1,3,4,28; max: 2,3,12,28
+rxnsList = [1; 2; 3; 4; 12; 28]
+rxnsOptMode = [0; 1; 2; 0; 1; 2] # min: 1, 3, 4, 28; max: 2, 3, 12, 28
 
 # run only a few reactions with rxnsOptMode and rxnsList
 minFlux, maxFlux, optSol, fbaSol, fvamin, fvamax, statussolmin, statussolmax = distributedFBA(model, solver, nWorkers, 90.0, "max", rxnsList, 0, rxnsOptMode)
 
 # test the solution status
-@test norm(statussolmin[rxnsList] - [1,-1,1,1,-1,1]) < 1e-9
-@test norm(statussolmax[rxnsList] - [-1,1,1,-1,1,1]) < 1e-9
-@test minFlux[1:4] != minFlux[[1,3,4,28]]
+@test norm(statussolmin[rxnsList] - [1, -1, 1, 1, -1, 1]) < 1e-9
+@test norm(statussolmax[rxnsList] - [-1, 1, 1, -1, 1, 1]) < 1e-9
+@test minFlux[1:4] != minFlux[[1, 3, 4, 28]]
 
 # test fbaSol vectors
 @test norm(fbaSol - fbaSol1) < 1e-9
@@ -61,16 +61,16 @@ minFlux, maxFlux, optSol, fbaSol, fvamin, fvamax, statussolmin, statussolmax = d
 #other solvers (e.g., CPLEX) might report alternate optimal solutions
 if solverName == "GLPKMathProgInterface"
     # test minimum and maximum flux vectors
-    @test norm(fvamin[:,[1,3,4,28]] - fvamin1[:,[1,3,4,28]]) < 1e-9
-    @test norm(fvamax[:,[2,3,12,28]] - fvamax1[:,[2,3,12,28]]) < 1e-9
+    @test norm(fvamin[:,[1, 3, 4, 28]] - fvamin1[:,[1, 3, 4, 28]]) < 1e-9
+    @test norm(fvamax[:,[2, 3, 12, 28]] - fvamax1[:,[2, 3, 12, 28]]) < 1e-9
 end
 
 # test rxnsOptMode and rxnsList criteria
-@test norm(minFlux[[1,3,4,28]] - minFlux1[[1,3,4,28]]) < 1e-9
-@test norm(maxFlux[[2,3,12,28]] - maxFlux1[[2,3,12,28]]) < 1e-9
+@test norm(minFlux[[1, 3, 4, 28]] - minFlux1[[1, 3, 4, 28]]) < 1e-9
+@test norm(maxFlux[[2, 3, 12, 28]] - maxFlux1[[2, 3, 12, 28]]) < 1e-9
 
 # run only the reactions of the rxnsList (both maximizations and minimizations)
-startTime   = time()
+startTime = time()
 minFlux, maxFlux, optSol, fbaSol, fvamin, fvamax, statussolmin, statussolmax = distributedFBA(model, solver, nWorkers, 90.0, "max", rxnsList)
 solTime = time() - startTime
 

--- a/test/p_range.jl
+++ b/test/p_range.jl
@@ -14,11 +14,11 @@ if !isdefined(:includeCOBRA) includeCOBRA = true end
 # output information
 testFile = @__FILE__
 
+# number of workers
 nWorkers = 4
 
 # create a pool and use the COBRA module if the testfile is run in a loop
 if includeCOBRA
-
     solverName = :GLPKMathProgInterface
     connectSSHWorkers = false
     include("$(dirname(@__FILE__))/../src/connect.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,8 +42,7 @@ end
 
 includeCOBRA = false
 
-for s in 1:length(packages)
-
+for s = 1:length(packages)
     # define a solvername
     solverName = string(packages[s])
 
@@ -54,7 +53,7 @@ for s in 1:length(packages)
     print_with_color(:green, "\n\n -- Running $(length(testDir) - 2) tests using the $solverName solver. -- \n\n")
 
     # evaluate the test file
-    for t in 1:length(testDir)
+    for t = 1:length(testDir)
         # run only parallel and serial test files
         if testDir[t][1:2] == "p_" || testDir[t][1:2] == "s_" || testDir[t][1:2] == "z_"
             print_with_color(:green, "\nRunning $(testDir[t]) ...\n\n")
@@ -64,6 +63,6 @@ for s in 1:length(packages)
 end
 
 # print a status line
-print_with_color(:green, "\n -- All tests passed. -- \n\n") 
+print_with_color(:green, "\n -- All tests passed. -- \n\n")
 
 #-------------------------------------------------------------------------------------------

--- a/test/s_all.jl
+++ b/test/s_all.jl
@@ -14,11 +14,11 @@ if !isdefined(:includeCOBRA) includeCOBRA = true end
 # output information
 testFile = @__FILE__
 
+# number of workers
 nWorkers = 1
 
 # create a pool and use the COBRA module if the testfile is run in a loop
 if includeCOBRA
-
     solverName = :GLPKMathProgInterface
     connectSSHWorkers = false
     include("$(dirname(@__FILE__))/../src/connect.jl")
@@ -44,7 +44,7 @@ model = loadModel("ecoli_core_model.mat", "S", "model")
 rxnsList = 1:length(model.rxns)
 
 # launch the distributedFBA process
-startTime   = time()
+startTime = time()
 minFlux, maxFlux, optSol, fbaSol, fvamin, fvamax, statussolmin, statussolmax = distributedFBA(model, solver, nWorkers, 90.0, "max", rxnsList)
 solTime = time() - startTime
 

--- a/test/s_core.jl
+++ b/test/s_core.jl
@@ -14,11 +14,11 @@ if !isdefined(:includeCOBRA) includeCOBRA = true end
 # output information
 testFile = @__FILE__
 
+# number of workers
 nWorkers = 1
 
 # create a pool and use the COBRA module if the testfile is run in a loop
 if includeCOBRA
-
     solverName = :GLPKMathProgInterface
     connectSSHWorkers = false
     include("$(dirname(@__FILE__))/../src/connect.jl")
@@ -60,7 +60,7 @@ solutionLP = solveCobraLP(model, solver)
 @test abs(solutionLP2.objval - solutionLP.objval) < 1e-9
 
 # launch the distributedFBA process
-startTime   = time()
+startTime = time()
 minFlux, maxFlux, optSol = distributedFBA(model, solver, nWorkers, 90.0, "max", rxnsList)
 solTime = time() - startTime
 
@@ -71,7 +71,7 @@ solTime = time() - startTime
 @test floor(minimum(minFlux)) == -36.0
 @test floor(norm(maxFlux))    == 1427.0
 @test floor(norm(minFlux))    == 93.0
-@test abs((- model.c'*minFlux)[1] - optSol) < 1e-9
+@test abs((- model.c' * minFlux)[1] - optSol) < 1e-9
 
 # save the variables to the current directory
 saveDistributedFBA("testFile.mat")

--- a/test/s_distinct.jl
+++ b/test/s_distinct.jl
@@ -14,11 +14,11 @@ if !isdefined(:includeCOBRA) includeCOBRA = true end
 # output information
 testFile = @__FILE__
 
+# number of workers
 nWorkers = 1
 
 # create a pool and use the COBRA module if the testfile is run in a loop
 if includeCOBRA
-
     solverName = :GLPKMathProgInterface
     connectSSHWorkers = false
     include("$(dirname(@__FILE__))/../src/connect.jl")

--- a/test/s_distinct.jl
+++ b/test/s_distinct.jl
@@ -60,10 +60,10 @@ minFlux, maxFlux, optSol, fbaSol, fvamin, fvamax, statussolmin, statussolmax = d
 #other solvers (e.g., CPLEX) might report alternate optimal solutions
 if solverName == "GLPKMathProgInterface"
     # test minimum flux vectors
-    @test norm(fvamin[:,20:30] - fvamin1[:,20:30]) < 1e-9
+    @test norm(fvamin[:,4:14] - fvamin1[:,20:30]) < 1e-9
 
     # text maximum flux vectors
-    @test norm(fvamax[:,20:30] - fvamax1[:,20:30]) < 1e-9
+    @test norm(fvamax[:,4:14] - fvamax1[:,20:30]) < 1e-9
 end
 
 # test rxnsOptMode and rxnsList criteria
@@ -83,10 +83,10 @@ solTime = time() - startTime
 #other solvers (e.g., CPLEX) might report alternate optimal solutions
 if solverName == "GLPKMathProgInterface"
     # test minimum flux vectors
-    @test norm(fvamin[:,20:30] - fvamin1[:,20:30]) < 1e-9
+    @test norm(fvamin[:,4:14] - fvamin1[:,20:30]) < 1e-9
 
     # text maximum flux vectors
-    @test norm(fvamax[:,20:30] - fvamax1[:,20:30]) < 1e-9
+    @test norm(fvamax[:,4:14] - fvamax1[:,20:30]) < 1e-9
 end
 
 # save the variables to the current directory

--- a/test/s_fba.jl
+++ b/test/s_fba.jl
@@ -14,11 +14,11 @@ if !isdefined(:includeCOBRA) includeCOBRA = true end
 # output information
 testFile = @__FILE__
 
+# number of workers
 nWorkers = 1
 
 # create a pool and use the COBRA module if the testfile is run in a loop
 if includeCOBRA
-
     solverName = :GLPKMathProgInterface
     connectSSHWorkers = false
     include("$(dirname(@__FILE__))/../src/connect.jl")
@@ -46,10 +46,7 @@ nWorkers = 1
 rxnsList = 13
 rxnsOptMode = 1  # maximization
 
-# -------------------------------------------------------------------------------------
-
 for s = 0:2
-
     # launch the distributedFBA process
     startTime   = time()
     minFlux, maxFlux, optSol, fbaSol, fvamin, fvamax, statussolmin, statussolmax = distributedFBA(model, solver, nWorkers, 10.0, "min", rxnsList, s, rxnsOptMode, false)
@@ -74,7 +71,7 @@ end
 model = modelOrig
 
 # launch the distributedFBA process with only 1 reaction
-startTime   = time()
+startTime = time()
 minFlux, maxFlux, optSol  = distributedFBA(model, solver, nWorkers, 100.0, "", rxnsList, 0, rxnsOptMode, false);
 solTime = time() - startTime
 

--- a/test/z_all.jl
+++ b/test/z_all.jl
@@ -14,11 +14,11 @@ if !isdefined(:includeCOBRA) includeCOBRA = true end
 # output information
 testFile = @__FILE__
 
+# number of workers
 nWorkers = 1
 
 # create a pool and use the COBRA module if the testfile is run in a loop
 if includeCOBRA
-
     solverName = :GLPKMathProgInterface
     connectSSHWorkers = false
     include("$(dirname(@__FILE__))/../src/connect.jl")
@@ -56,21 +56,21 @@ print_with_color(:yellow, "\n>> The following tests might throw warning messages
 @test_throws ErrorException loadModel("ecoli_core_model.mat", "S", "myModel")
 
 # call other fields of the model
-@test_throws ErrorException loadModel("ecoli_core_model.mat","S","model",["ubTest","lb","osense","c","b","csense","rxns","mets"])
-@test_throws ErrorException loadModel("ecoli_core_model.mat","S","model",["ub","lbTest","osense","c","b","csense","rxns","mets"])
-@test_throws ErrorException loadModel("ecoli_core_model.mat","S","model",["ub","lb","osense","cTest","b","csense","rxns","mets"])
-@test_throws ErrorException loadModel("ecoli_core_model.mat","S","model",["ub","lb","osense","c","bTest","csense","rxns","mets"])
-@test_throws ErrorException loadModel("ecoli_core_model.mat","S","model",["ub","lb","osense","c","b","csense","rxnsTest","mets"])
-@test_throws ErrorException loadModel("ecoli_core_model.mat","S","model",["ub","lb","osense","c","b","csense","rxns","metsTest"])
+@test_throws ErrorException loadModel("ecoli_core_model.mat", "S", "model", ["ubTest", "lb", "osense", "c", "b", "csense", "rxns", "mets"])
+@test_throws ErrorException loadModel("ecoli_core_model.mat", "S", "model", ["ub", "lbTest", "osense", "c", "b", "csense", "rxns", "mets"])
+@test_throws ErrorException loadModel("ecoli_core_model.mat", "S", "model", ["ub", "lb", "osense", "cTest", "b", "csense", "rxns", "mets"])
+@test_throws ErrorException loadModel("ecoli_core_model.mat", "S", "model", ["ub", "lb", "osense", "c", "bTest", "csense", "rxns", "mets"])
+@test_throws ErrorException loadModel("ecoli_core_model.mat", "S", "model", ["ub", "lb", "osense", "c", "b", "csense", "rxnsTest", "mets"])
+@test_throws ErrorException loadModel("ecoli_core_model.mat", "S", "model", ["ub", "lb", "osense", "c", "b", "csense", "rxns", "metsTest"])
 
 # connect SSH workers that are not reachable
-@test createPool(1, false) == (workers(),1)
+@test createPool(1, false) == (workers(), 1)
 @test_throws ErrorException workersPool, nWorkers = createPool(0, false)
 @test_throws ErrorException workersPool, nWorkers = createPool(nWorkers+1, true)
 
 # connect twice the same number of workers
-@test createPool(4) == (workers(),4)
-@test createPool(2) == (workers(),2)
+@test createPool(4) == (workers(), 4)
+@test createPool(2) == (workers(), 2)
 
 # load a new version of the model
 model=loadModel("ecoli_core_model.mat")
@@ -96,7 +96,7 @@ solver.handle = -1
 
 # test if an infeasible solution status is returned
 solver = changeCobraSolver(solverName, solParams)
-m = MathProgBase.HighLevelInterface.buildlp([1.0,0.0],[2.0 1.0],'<',-1.0,solver.handle)
+m = MathProgBase.HighLevelInterface.buildlp([1.0, 0.0],[2.0 1.0], '<', -1.0, solver.handle)
 retObj, retFlux, retStat = loopFBA(m, 1, 2)
 if solverName == "Clp" || solverName == "Gurobi" || solverName == "CPLEX" || solverName == "Mosek"
     @test retStat[1] == 0 # infeasible
@@ -110,7 +110,7 @@ modelTest = loadModel("ecoli_core_model.mat", "S", "modelTest")
 @test modelTest.csense == fill('E',length(modelTest.b))
 
 # test buildlp and solvelp for an unbounded problem
-m = MathProgBase.HighLevelInterface.buildlp([-1.0,-1.0],[-1.0 2.0],'<',[0.0],solver.handle)
+m = MathProgBase.HighLevelInterface.buildlp([-1.0, -1.0],[-1.0 2.0],'<',[0.0], solver.handle)
 sol = MathProgBase.HighLevelInterface.solvelp(m)
 if solver.name == "Clp" || solver.name == "Gurobi" || solver.name == "GLPK" || solver.name == "Mosek"
     @test sol.status == :Unbounded
@@ -119,7 +119,7 @@ elseif solverName == "CPLEX"
 end
 
 # solve an unbounded problem using loopFBA
-m = MathProgBase.HighLevelInterface.buildlp([0.0,-1.0],[-1.0 2.0],'<',[0.0],solver.handle)
+m = MathProgBase.HighLevelInterface.buildlp([0.0, -1.0],[-1.0 2.0],'<',[0.0], solver.handle)
 retObj, retFlux, retStat = loopFBA(m, 1, 2, 2, 1)
 if solver.name == "Clp" || solver.name == "Gurobi" || solver.name == "GLPK" || solver.name == "Mosek"
     @test retStat == [2, -1] # unbounded and not solved


### PR DESCRIPTION
**Major changes**

- Instead of storing the return flux vectors as a full matrix on each worker `p`, the `retFlux` matrix stores the number only the number of flux vectors that are actually being calculating on worker `p`
- Saving individual files of fvamin and fvamax for very large models; introduction of `saveChunks` variable in `distributedFBA()`
- Creation of `results/` folder if `saveChunks` is set to `true`
- Tests for saving individual files

**Minor changes**

- Minor formatting changes
- Exclusions of `results/` folder in `.gitignore`

*All tests pass on Linux, Julia 0.5. CI integrated version.*