### PR TITLE
use more specific condition for when to define local @isdefined macro

### DIFF
--- a/src/checkSetup.jl
+++ b/src/checkSetup.jl
@@ -113,7 +113,7 @@ function checkSysConfig(verbose = 1)
 end
 
 # fix deprecation warnings in Julia 0.7
-if VERSION.major == 0 && VERSION.minor < 7
+if !isdefined(Base, Symbol("@isdefined"))
     macro isdefined(symbol)
         return isdefined(symbol)
     end


### PR DESCRIPTION
this should still work on earlier 0.7-dev versions that predate the macro