### PR TITLE
change location of a HTTP GET in test code from LCSB-BioCore to opencobra

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,12 @@
+pipeline {
+  agent any
+  stages {
+    stage('Build') {
+      steps {
+        sh '''/home/vmhadmin/julia-1.2.0/bin/julia --color=yes -e \'import Pkg; Pkg.clone(pwd()); Pkg.test("COBRA", coverage=true); Pkg.rm("COBRA");\'
+'''
+      }
+    }
+
+  }
+}

--- a/test/getTestModel.jl
+++ b/test/getTestModel.jl
@@ -2,7 +2,7 @@ function getTestModel()
 
     if !isfile("ecoli_core_model.mat")
         print("Downloading the ecoli_core model ...")
-        ecoliModel = HTTP.get("https://github.com/LCSB-BioCore/COBRA.models/raw/master/mat/ecoli_core_model.mat")
+        ecoliModel = HTTP.get("https://github.com/opencobra/COBRA.models/raw/master/mat/ecoli_core_model.mat")
         write("ecoli_core_model.mat", ecoliModel.body)
         printstyled("Done.\n"; color=:green)
     else


### PR DESCRIPTION
A line in  test/getTestModel.jl which retrieves ecoli_core model by HTTP GET to Github needs to be updated from 
https://github.com/LCSB-BioCore/COBRA.models/raw/master/mat/ecoli_core_model.mat (repo no longer exists there) to https://github.com/opencobra/COBRA.models/raw/master/mat/ecoli_core_model.mat

After this change the CI test completes successfully on king.nuigalway.ie